### PR TITLE
Custom backing store for Kafka Connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,30 @@
 Apache Kafka
 =================
+
+
+### Building and deploying steps with custom changes
+
+```
+debraj@Nexlas-MacBook-Pro upload % cd ~/code/java/github/nexla/confluent-kafka
+debraj@Nexlas-MacBook-Pro confluent-kafka % ./gradlew publishToMavenLocal -PskipSigning=true
+```
+
+The above command will put the below jars under local repository (`~/.m2/repository`)
+```
+debraj@Nexlas-MacBook-Pro repository % cd ~/.m2/repository/org/apache/kafka/connect-runtime/7.9.0-hack-ccs
+debraj@Nexlas-MacBook-Pro 7.9.0-hack-ccs % ls
+connect-runtime-7.9.0-hack-ccs-javadoc.jar	connect-runtime-7.9.0-hack-ccs-test-sources.jar	connect-runtime-7.9.0-hack-ccs.jar		connect-runtime-7.9.0-hack-ccs.pom
+connect-runtime-7.9.0-hack-ccs-sources.jar	connect-runtime-7.9.0-hack-ccs-test.jar		connect-runtime-7.9.0-hack-ccs.module
+```
+
+#### Raising PRs for tracking
+Just for easier visibility of the changes, follow the below steps and raise a draft PR
+
+#### Pushing kafka client artifact to AWS Code Artifactory
+Publish `connect-runtime-7.9.0-hack-ccs.jar` and `connect-runtime-7.9.0-hack-ccs.pom` to artifactory using the steps outlined [here](https://nexla1.atlassian.net/browse/NEX-18101).
+
+### Building Confluent Kafka ###
+
 See our [web site](https://kafka.apache.org) for details on the project.
 
 You need to have [Java](http://www.oracle.com/technetwork/java/javase/downloads/index.html) installed.

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
@@ -18,25 +18,16 @@ package org.apache.kafka.connect.cli;
 
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
-import org.apache.kafka.connect.json.JsonConverter;
-import org.apache.kafka.connect.json.JsonConverterConfig;
-import org.apache.kafka.connect.runtime.Worker;
-import org.apache.kafka.connect.runtime.WorkerConfigTransformer;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.runtime.distributed.DistributedHerder;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.runtime.rest.RestClient;
 import org.apache.kafka.connect.runtime.rest.RestServer;
-import org.apache.kafka.connect.storage.ConfigBackingStore;
-import org.apache.kafka.connect.storage.Converter;
-import org.apache.kafka.connect.storage.KafkaConfigBackingStore;
-import org.apache.kafka.connect.storage.KafkaOffsetBackingStore;
-import org.apache.kafka.connect.storage.KafkaStatusBackingStore;
-import org.apache.kafka.connect.storage.StatusBackingStore;
 import org.apache.kafka.connect.util.ConnectUtils;
 import org.apache.kafka.connect.util.SharedTopicAdmin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -52,7 +43,8 @@ import static org.apache.kafka.clients.CommonClientConfigs.CLIENT_ID_CONFIG;
  * </p>
  */
 public class ConnectDistributed extends AbstractConnectCli<DistributedHerder, DistributedConfig> {
-
+    private static final Logger log = LoggerFactory.getLogger(ConnectDistributed.class);
+    private static final Time time = Time.SYSTEM;
     public ConnectDistributed(String... args) {
         super(args);
     }
@@ -66,40 +58,17 @@ public class ConnectDistributed extends AbstractConnectCli<DistributedHerder, Di
     protected DistributedHerder createHerder(DistributedConfig config, String workerId, Plugins plugins,
                                   ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy,
                                   RestServer restServer, RestClient restClient) {
-
+        log.info("Initializing Worker id {}", workerId);
         String kafkaClusterId = config.kafkaClusterId();
         String clientIdBase = ConnectUtils.clientIdBase(config);
-        // Create the admin client to be shared by all backing stores.
         Map<String, Object> adminProps = new HashMap<>(config.originals());
         ConnectUtils.addMetricsContextProperties(adminProps, config, kafkaClusterId);
         adminProps.put(CLIENT_ID_CONFIG, clientIdBase + "shared-admin");
         SharedTopicAdmin sharedAdmin = new SharedTopicAdmin(adminProps);
-
-        KafkaOffsetBackingStore offsetBackingStore = new KafkaOffsetBackingStore(sharedAdmin, () -> clientIdBase,
-                plugins.newInternalConverter(true, JsonConverter.class.getName(),
-                        Collections.singletonMap(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, "false")));
-        offsetBackingStore.configure(config);
-
-        Worker worker = new Worker(workerId, Time.SYSTEM, plugins, config, offsetBackingStore, connectorClientConfigOverridePolicy);
-        WorkerConfigTransformer configTransformer = worker.configTransformer();
-
-        Converter internalValueConverter = worker.getInternalValueConverter();
-        StatusBackingStore statusBackingStore = new KafkaStatusBackingStore(Time.SYSTEM, internalValueConverter, sharedAdmin, clientIdBase);
-        statusBackingStore.configure(config);
-
-        ConfigBackingStore configBackingStore = new KafkaConfigBackingStore(
-                internalValueConverter,
-                config,
-                configTransformer,
-                sharedAdmin,
-                clientIdBase);
-
-        // Pass the shared admin to the distributed herder as an additional AutoCloseable object that should be closed when the
-        // herder is stopped. This is easier than having to track and own the lifecycle ourselves.
-        return new DistributedHerder(config, Time.SYSTEM, worker,
-                kafkaClusterId, statusBackingStore, configBackingStore,
-                restServer.advertisedUrl().toString(), restClient, connectorClientConfigOverridePolicy,
-                Collections.emptyList(), sharedAdmin);
+        final DistributedHerder herder = new KafkaConnectTopicsBuilder()
+                .buildDistributedHerder(plugins, config, kafkaClusterId, restServer.advertisedUrl(), workerId, sharedAdmin, time, restClient);
+        log.info("Initialized Worker id {}", workerId);
+        return herder;
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/DeletionKafkaOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/DeletionKafkaOffsetBackingStore.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.cli;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.connect.runtime.WorkerConfig;
+import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
+import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.storage.OffsetBackingStore;
+import org.apache.kafka.connect.storage.OffsetUtils;
+import org.apache.kafka.connect.util.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+/**
+ * <p>
+ *     Implementation of OffsetBackingStore that uses a Kafka topic to store offset data.
+ * </p>
+ * <p>
+ *     Internally, this implementation both produces to and consumes from a Kafka topic which stores the offsets.
+ *     It accepts producer and consumer overrides via its configuration but forces some settings to specific values
+ *     to ensure correct behavior (e.g. acks, auto.offset.reset).
+ * </p>
+ */
+public class DeletionKafkaOffsetBackingStore implements OffsetBackingStore {
+    private static final Logger log = LoggerFactory.getLogger(DeletionKafkaOffsetBackingStore.class);
+    private final Map<String, Set<Map<String, Object>>> connectorPartitions = new HashMap<>();
+    private KafkaBasedLog<byte[], byte[]> offsetLog;
+    private HashMap<ByteBuffer, ByteBuffer> data;
+    private final Supplier<TopicAdmin> topicAdminSupplier;
+    private SharedTopicAdmin ownTopicAdmin;
+    private final Converter keyConverter;
+
+    public DeletionKafkaOffsetBackingStore(Supplier<TopicAdmin> topicAdmin, Converter keyConverter) {
+        this.topicAdminSupplier = Objects.requireNonNull(topicAdmin);
+        this.keyConverter = keyConverter;
+    }
+
+    @Override
+    public void configure(final WorkerConfig config) {
+        String topic = config.getString(DistributedConfig.OFFSET_STORAGE_TOPIC_CONFIG);
+        if (topic == null || topic.trim().isEmpty())
+            throw new ConfigException("Offset storage topic must be specified");
+
+        String clusterId = config.kafkaClusterId();
+        data = new HashMap<>();
+
+        Map<String, Object> originals = config.originals();
+        Map<String, Object> producerProps = new HashMap<>(originals);
+        producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+        producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+        producerProps.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, Integer.MAX_VALUE);
+        ConnectUtils.addMetricsContextProperties(producerProps, config, clusterId);
+
+        Map<String, Object> consumerProps = new HashMap<>(originals);
+        consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+        consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+        ConnectUtils.addMetricsContextProperties(consumerProps, config, clusterId);
+
+        Map<String, Object> adminProps = new HashMap<>(originals);
+        ConnectUtils.addMetricsContextProperties(adminProps, config, clusterId);
+        Map<String, Object> topicSettings = config instanceof DistributedConfig
+                ? ((DistributedConfig) config).offsetStorageTopicSettings()
+                : Collections.emptyMap();
+        NewTopic topicDescription = TopicAdmin.defineTopic(topic)
+                .config(topicSettings) // first so that we override user-supplied settings as needed
+                .partitions(config.getInt(DistributedConfig.OFFSET_STORAGE_PARTITIONS_CONFIG))
+                .replicationFactor(config.getShort(DistributedConfig.OFFSET_STORAGE_REPLICATION_FACTOR_CONFIG))
+                .build();
+
+        offsetLog = createKafkaBasedLog(topic, producerProps, consumerProps, consumedCallback, topicDescription, topicAdminSupplier);
+    }
+
+    private KafkaBasedLog<byte[], byte[]> createKafkaBasedLog(String topic, Map<String, Object> producerProps,
+                                                              Map<String, Object> consumerProps,
+                                                              Callback<ConsumerRecord<byte[], byte[]>> consumedCallback,
+                                                              final NewTopic topicDescription, Supplier<TopicAdmin> adminSupplier) {
+        java.util.function.Consumer<TopicAdmin> createTopics = admin -> {
+            log.debug("Creating admin client to manage Connect internal offset topic");
+            // Create the topic if it doesn't exist
+            admin.createTopics(topicDescription);
+        };
+        return new KafkaBasedLog<>(topic, producerProps, consumerProps, adminSupplier, consumedCallback, Time.SYSTEM, createTopics);
+    }
+
+    @Override
+    public void start() {
+        log.info("Starting DeletionKafkaOffsetBackingStore");
+        offsetLog.start();
+        log.info("Finished reading offsets topic and starting DeletionKafkaOffsetBackingStore");
+    }
+
+    @Override
+    public void stop() {
+        log.info("Stopping DeletionKafkaOffsetBackingStore");
+        try {
+            offsetLog.stop();
+        } finally {
+            if (ownTopicAdmin != null) {
+                ownTopicAdmin.close();
+            }
+        }
+        log.info("Stopped DeletionKafkaOffsetBackingStore");
+    }
+
+    @Override
+    public Future<Map<ByteBuffer, ByteBuffer>> get(final Collection<ByteBuffer> keys) {
+        ConvertingFutureCallback<Void, Map<ByteBuffer, ByteBuffer>> future = new ConvertingFutureCallback<Void, Map<ByteBuffer, ByteBuffer>>() {
+            @Override
+            public Map<ByteBuffer, ByteBuffer> convert(Void result) {
+                Map<ByteBuffer, ByteBuffer> values = new HashMap<>();
+                for (ByteBuffer key : keys)
+                    values.put(key, data.get(key));
+                return values;
+            }
+        };
+        // This operation may be relatively (but not too) expensive since it always requires checking end offsets, even
+        // if we've already read up to the end. However, it also should not be common (offsets should only be read when
+        // resetting a task). Always requiring that we read to the end is simpler than trying to differentiate when it
+        // is safe not to (which should only be if we *know* we've maintained ownership since the last write).
+        offsetLog.readToEnd(future);
+        return future;
+    }
+
+    @Override
+    public Future<Void> set(final Map<ByteBuffer, ByteBuffer> values, final Callback<Void> callback) {
+        SetCallbackFuture producerCallback = new SetCallbackFuture(values.size(), callback);
+
+        for (Map.Entry<ByteBuffer, ByteBuffer> entry : values.entrySet()) {
+            ByteBuffer key = entry.getKey();
+            ByteBuffer value = entry.getValue();
+            offsetLog.send(key == null ? null : key.array(), value == null ? null : value.array(), producerCallback);
+        }
+
+        return producerCallback;
+    }
+
+    @Override
+    public Set<Map<String, Object>> connectorPartitions(String connectorName) {
+        return connectorPartitions.getOrDefault(connectorName, Collections.emptySet());
+    }
+
+    private final Callback<ConsumerRecord<byte[], byte[]>> consumedCallback = new Callback<ConsumerRecord<byte[], byte[]>>() {
+        @Override
+        public void onCompletion(Throwable error, ConsumerRecord<byte[], byte[]> rec) {
+            OffsetUtils.processPartitionKey(rec.key(), rec.value(), keyConverter, connectorPartitions);
+            ByteBuffer key = rec.key() != null ? ByteBuffer.wrap(rec.key()) : null;
+            ByteBuffer value = rec.value() != null ? ByteBuffer.wrap(rec.value()) : null;
+            data.put(key, value);
+        }
+    };
+
+    private static class SetCallbackFuture implements org.apache.kafka.clients.producer.Callback, Future<Void> {
+        private int numLeft;
+        private boolean completed = false;
+        private Throwable exception = null;
+        private final Callback<Void> callback;
+
+        public SetCallbackFuture(int numRecords, Callback<Void> callback) {
+            numLeft = numRecords;
+            this.callback = callback;
+        }
+
+        @Override
+        public synchronized void onCompletion(RecordMetadata metadata, Exception exception) {
+            if (exception != null) {
+                if (!completed) {
+                    this.exception = exception;
+                    callback.onCompletion(exception, null);
+                    completed = true;
+                    this.notify();
+                }
+                return;
+            }
+
+            numLeft -= 1;
+            if (numLeft == 0) {
+                callback.onCompletion(null, null);
+                completed = true;
+                this.notify();
+            }
+        }
+
+        @Override
+        public synchronized boolean cancel(boolean mayInterruptIfRunning) {
+            return false;
+        }
+
+        @Override
+        public synchronized boolean isCancelled() {
+            return false;
+        }
+
+        @Override
+        public synchronized boolean isDone() {
+            return completed;
+        }
+
+        @Override
+        public synchronized Void get() throws InterruptedException, ExecutionException {
+            while (!completed) {
+                this.wait();
+            }
+            if (exception != null)
+                throw new ExecutionException(exception);
+            return null;
+        }
+
+        @Override
+        public synchronized Void get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            long started = System.currentTimeMillis();
+            long limit = started + unit.toMillis(timeout);
+            while (!completed) {
+                long leftMs = limit - System.currentTimeMillis();
+                if (leftMs < 0)
+                    throw new TimeoutException("KafkaOffsetBackingStore Future timed out.");
+                this.wait(leftMs);
+            }
+            if (exception != null)
+                throw new ExecutionException(exception);
+            return null;
+        }
+    }
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/KafkaConnectTopicsBuilder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/KafkaConnectTopicsBuilder.java
@@ -1,0 +1,94 @@
+package org.apache.kafka.connect.cli;
+
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.json.JsonConverterConfig;
+import org.apache.kafka.connect.runtime.Worker;
+import org.apache.kafka.connect.runtime.WorkerConfig;
+import org.apache.kafka.connect.runtime.WorkerConfigTransformer;
+import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
+import org.apache.kafka.connect.runtime.distributed.DistributedHerder;
+import org.apache.kafka.connect.runtime.isolation.Plugins;
+import org.apache.kafka.connect.runtime.rest.RestClient;
+import org.apache.kafka.connect.storage.*;
+import org.apache.kafka.connect.util.ConnectUtils;
+import org.apache.kafka.connect.util.SharedTopicAdmin;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Optional;
+
+
+public class KafkaConnectTopicsBuilder {
+
+    public final boolean memoryKafkaConnectConfigTopics;
+    public final boolean memoryKafkaConnectStatusTopics;
+    public final boolean memoryKafkaConnectOffsetTopics;
+    public final boolean deletionKafkaConnectOffsetTopics;
+
+    public KafkaConnectTopicsBuilder() {
+        this.memoryKafkaConnectConfigTopics = checkEnvBoolean("MEMORY_KAFKA_CONNECT_CONFIG_TOPICS");
+        this.memoryKafkaConnectStatusTopics = checkEnvBoolean("MEMORY_KAFKA_CONNECT_STATUS_TOPICS");
+        this.memoryKafkaConnectOffsetTopics = checkEnvBoolean("MEMORY_KAFKA_CONNECT_OFFSET_TOPICS");
+        this.deletionKafkaConnectOffsetTopics = checkEnvBoolean("DELETION_KAFKA_CONNECT_OFFSET_TOPICS");
+    }
+
+    private static boolean checkEnvBoolean(String disableKafkaConnectConfigTopics) {
+        return Optional.ofNullable(System.getenv(disableKafkaConnectConfigTopics))
+                .map(Boolean::valueOf)
+                .orElse(false);
+    }
+
+    public DistributedHerder buildDistributedHerder(Plugins plugins,
+                                                    DistributedConfig config,
+                                                    String kafkaClusterId,
+                                                    URI advertisedUrl,
+                                                    String workerId,
+                                                    SharedTopicAdmin sharedAdmin,
+                                                    Time time,
+                                                    RestClient restClient) {
+
+        final Converter keyConverter = plugins.newInternalConverter(true, JsonConverter.class.getName(),
+                Collections.singletonMap(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, "false"));
+
+        OffsetBackingStore offsetBackingStore = getOffsetBackingStore(sharedAdmin, config, keyConverter);
+        offsetBackingStore.configure(config);
+        final String clientIdBase = ConnectUtils.clientIdBase(config);
+
+        ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy = plugins.newPlugin(
+                config.getString(WorkerConfig.CONNECTOR_CLIENT_POLICY_CLASS_CONFIG),
+                config, ConnectorClientConfigOverridePolicy.class);
+
+        Worker worker = new Worker(workerId, time, plugins, config, offsetBackingStore, connectorClientConfigOverridePolicy);
+        WorkerConfigTransformer configTransformer = worker.configTransformer();
+
+        Converter internalValueConverter = worker.getInternalValueConverter();
+
+        StatusBackingStore statusBackingStore = memoryKafkaConnectStatusTopics ?
+                new MemoryStatusBackingStore() :
+                new KafkaStatusBackingStore(time, internalValueConverter, sharedAdmin, clientIdBase);
+        statusBackingStore.configure(config);
+
+        ConfigBackingStore configBackingStore = memoryKafkaConnectConfigTopics ?
+                new MemoryConfigBackingStore(configTransformer) :
+                new KafkaConfigBackingStore(internalValueConverter, config, configTransformer, sharedAdmin, clientIdBase);
+
+        // Pass the shared admin to the distributed herder as an additional AutoCloseable object that should be closed when the
+        // herder is stopped. This is easier than having to track and own the lifecycle ourselves.
+        return new DistributedHerder(config, time, worker,
+                kafkaClusterId, statusBackingStore, configBackingStore,
+                advertisedUrl.toString(), restClient, connectorClientConfigOverridePolicy, new ArrayList<>());
+    }
+
+    private OffsetBackingStore getOffsetBackingStore(SharedTopicAdmin sharedAdmin, WorkerConfig config, Converter keyConverter) {
+        if (memoryKafkaConnectOffsetTopics) {
+            return new MemoryOffsetBackingStoreImpl(keyConverter);
+        }
+        if (deletionKafkaConnectOffsetTopics) {
+            return new DeletionKafkaOffsetBackingStore(sharedAdmin, keyConverter);
+        }
+        return new KafkaOffsetBackingStore(sharedAdmin, () -> ConnectUtils.clientIdBase(config), keyConverter);
+    }
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/MemoryOffsetBackingStoreImpl.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/MemoryOffsetBackingStoreImpl.java
@@ -1,0 +1,35 @@
+package org.apache.kafka.connect.cli;
+
+import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.storage.MemoryOffsetBackingStore;
+import org.apache.kafka.connect.storage.OffsetUtils;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class MemoryOffsetBackingStoreImpl extends MemoryOffsetBackingStore {
+    private final Map<String, Set<Map<String, Object>>> connectorPartitions = new HashMap<>();
+    private final Converter keyConverter;
+
+    public MemoryOffsetBackingStoreImpl(Converter keyConverter) {
+        this.keyConverter = keyConverter;
+    }
+
+    @Override
+    public Set<Map<String, Object>> connectorPartitions(String connectorName) {
+        return connectorPartitions.getOrDefault(connectorName, Collections.emptySet());
+    }
+
+    @Override
+    protected void save() {
+        for (Map.Entry<ByteBuffer, ByteBuffer> mapEntry : data.entrySet()) {
+            byte[] key = (mapEntry.getKey() != null) ? mapEntry.getKey().array() : null;
+            byte[] value = (mapEntry.getValue() != null) ? mapEntry.getValue().array() : null;
+            OffsetUtils.processPartitionKey(key, value, keyConverter, connectorPartitions);
+        }
+    }
+
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ group=org.apache.kafka
 #  - streams/quickstart/pom.xml
 #  - streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
 #  - streams/quickstart/java/pom.xml
-version=7.9.0-ccs
+version=7.9.0-hack-ccs
 scalaVersion=2.13.14
 # Adding swaggerVersion in gradle.properties to have a single version in place for swagger
 # New version of Swagger 2.2.14 requires minimum JDK 11.


### PR DESCRIPTION
## Pull Request Overview

This PR introduces a custom backing store implementation for Kafka Connect that allows runtime switching between memory-based and Kafka-based storage for offsets, status, and configuration data through environment variables.

- Adds three new classes: `MemoryOffsetBackingStoreImpl`, `KafkaConnectTopicsBuilder`, and `DeletionKafkaOffsetBackingStore`
- Refactors `ConnectDistributed` to use the new `KafkaConnectTopicsBuilder` instead of directly creating backing stores
- Enables environment variable-based configuration for backing store selection

### Reviewed Changes

Copilot reviewed 4 out of 4 changed files in this pull request and generated 5 comments.

| File | Description |
| ---- | ----------- |
| MemoryOffsetBackingStoreImpl.java | New memory-based offset backing store implementation extending existing MemoryOffsetBackingStore |
| KafkaConnectTopicsBuilder.java | New builder class that creates distributed herder with configurable backing stores based on environment variables |
| DeletionKafkaOffsetBackingStore.java | New Kafka-based offset backing store implementation with deletion capabilities |
| ConnectDistributed.java | Refactored to use KafkaConnectTopicsBuilder instead of directly instantiating backing stores |
